### PR TITLE
Fixed behavior of/around some code that could throw NPE's

### DIFF
--- a/protex-sdk-examples/src/main/java/com/blackducksoftware/sdk/protex/client/examples/SampleAddBomComponentVersion.java
+++ b/protex-sdk-examples/src/main/java/com/blackducksoftware/sdk/protex/client/examples/SampleAddBomComponentVersion.java
@@ -102,13 +102,13 @@ public class SampleAddBomComponentVersion extends BDProtexSample {
 
             try {
                 List<Component> versions = componentApi.getComponentsByName(componentName, versionName);
-                if (versions != null || versions.size() == 1) {
+                if (versions != null && versions.size() == 1) {
                     version = versions.get(0);
                 } else {
-                    throw new RuntimeException("ComponentApi.getComponentByName() failed - multiple versions found with same name");
+                    throw new RuntimeException("ComponentApi.getComponentsByName() failed - " + (versions != null ? "multiple" : "no") + " versions found");
                 }
             } catch (SdkFault e) {
-                System.err.println("ComponentApi.getComponentByName() failed");
+                System.err.println("ComponentApi.getComponentsByName() failed: " + e.getMessage());
                 throw new RuntimeException(e);
             }
 

--- a/protex-sdk-examples/src/main/java/com/blackducksoftware/sdk/protex/client/examples/SampleCloneProject.java
+++ b/protex-sdk-examples/src/main/java/com/blackducksoftware/sdk/protex/client/examples/SampleCloneProject.java
@@ -110,11 +110,11 @@ public class SampleCloneProject extends BDProtexSample {
             try {
                 clonedProject = projectApi.getProjectById(clonedProjectId);
             } catch (Exception e) {
-                System.err.println("Failed to clone project " + clonedProject.getName() + " to " + clonedProjectName);
+                System.err.println("Failed to clone project " + project.getName() + " to " + clonedProjectName);
                 System.exit(1);
             }
             if (clonedProject == null) {
-                System.err.println("Failed to clone project " + clonedProject.getName() + " to " + clonedProjectName);
+                System.err.println("Failed to clone project " + project.getName() + " to " + clonedProjectName);
                 System.exit(1);
             }
 

--- a/protex-sdk-examples/src/main/java/com/blackducksoftware/sdk/protex/client/examples/SampleGetCustomComponentByName.java
+++ b/protex-sdk-examples/src/main/java/com/blackducksoftware/sdk/protex/client/examples/SampleGetCustomComponentByName.java
@@ -74,13 +74,13 @@ public class SampleGetCustomComponentByName extends BDProtexSample {
 
             try {
                 List<Component> components = componentApi.getComponentsByName(ccName, null);
-                if (components != null || components.size() == 1) {
+                if (components != null && components.size() == 1) {
                     customComponent = components.get(0);
                 } else {
-                    throw new RuntimeException("getCustomComponentByName() failed - multiple versions found with same name");
+                    throw new RuntimeException("ComponentApi.getComponentsByName() failed - " + (components != null ? "multiple" : "no") + " versions found");
                 }
             } catch (SdkFault e) {
-                System.err.println("getCustomComponentByName() failed: " + e.getMessage());
+                System.err.println("ComponentApi.getComponentsByName() failed: " + e.getMessage());
                 throw new RuntimeException(e);
             }
 

--- a/protex-sdk-examples/src/main/java/com/blackducksoftware/sdk/protex/client/examples/SampleListLicensesInPagesOf25.java
+++ b/protex-sdk-examples/src/main/java/com/blackducksoftware/sdk/protex/client/examples/SampleListLicensesInPagesOf25.java
@@ -93,8 +93,8 @@ public class SampleListLicensesInPagesOf25 extends BDProtexSample {
                         System.out.println("License: " + license.getName() + " (" + license.getLicenseId() + ")");
                     }
                 }
-                pageFilter = (LicenseInfoPageFilter) PageFilterFactory.getNextPage(pageFilter);
-            } while (licenses.size() >= pageSize - 1);
+                pageFilter = PageFilterFactory.getNextPage(pageFilter);
+            } while ((licenses != null) && (licenses.size() >= pageSize - 1));
         } catch (Exception e) {
             System.err.println("SampleListLicensesInPagesOf25 failed");
             e.printStackTrace(System.err);

--- a/protex-sdk-examples/src/main/java/com/blackducksoftware/sdk/protex/client/examples/report/SampleReportDataCodeMatchesPrecision.java
+++ b/protex-sdk-examples/src/main/java/com/blackducksoftware/sdk/protex/client/examples/report/SampleReportDataCodeMatchesPrecision.java
@@ -190,7 +190,7 @@ public class SampleReportDataCodeMatchesPrecision extends BDProtexSample {
                     }
 
                     System.out.println(String.format(rowFormat, codeMatchDiscovery.getFilePath(),
-                            thisFilesInfo.getLength(),
+                            thisFilesInfo != null ? thisFilesInfo.getLength() : "",
                             codeMatchDiscovery.getSourceFileLocation().getSnippet().getFirstLine(),
                             matchedSnippet.getFirstLine(), generalComponent.getComponentName(), versionName, licenseName,
                             status,


### PR DESCRIPTION
With Eclipse set to flag provable null pointer accesses as errors, three errors came up. These seemed to be due to minor logic/copy-paste errors. The intentions of the code seemed fairly clear, so I made what seemed like the logical fixes.

While I was looking at these errors, I also fixed/clarified some related error messages.
