### PR TITLE
Change maximum data elements type from a long to an int

### DIFF
--- a/protex-sdk-utilities/src/main/java/com/blackducksoftware/sdk/protex/client/util/ProtexServerProxy.java
+++ b/protex-sdk-utilities/src/main/java/com/blackducksoftware/sdk/protex/client/util/ProtexServerProxy.java
@@ -112,7 +112,7 @@ public class ProtexServerProxy implements Closeable {
     private long defaultTimeout = INDEFINITE_TIMEOUT;
 
     /** The default limit for returned list size */
-    private long maximumChildElements = 1000000;
+    private int maximumChildElements = 1000000;
 
     /** Any cookies to set on the HTTP request */
     private Map<String, List<String>> requestCookies = new HashMap<String, List<String>>();
@@ -359,7 +359,7 @@ public class ProtexServerProxy implements Closeable {
      * @param maximumChildElements
      *            The maximum number of elements allowed in returned lists
      */
-    public void setMaximumChildElements(long maximumChildElements) {
+    public void setMaximumChildElements(int maximumChildElements) {
         this.maximumChildElements = maximumChildElements;
     }
 


### PR DESCRIPTION
The maximum child elements property in CXF only accepts values in the
integer range, but the API accepts a long. This can result in underflow
errors, which ends up using the default value for the property